### PR TITLE
Fix service workers in Chome M45

### DIFF
--- a/app/Resources/public/js/app.js
+++ b/app/Resources/public/js/app.js
@@ -89,7 +89,7 @@ function push_subscribe() {
     pushButton.disabled = true;
 
     navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
-        serviceWorkerRegistration.pushManager.subscribe()
+        serviceWorkerRegistration.pushManager.subscribe({userVisibleOnly: true})
         .then(function(subscription) {
             // The subscription was successful
             isPushEnabled = true;
@@ -162,6 +162,7 @@ function push_unsubscribe() {
 }
 
 function push_sendSubscriptionToServer(subscription, action) {
+    subscription = getSubscriptionInfos(subscription);
     var req = new XMLHttpRequest();
     var params = "id=" + subscription.subscriptionId + "&endpoint="+ subscription.endpoint;
     var url = Routing.generate('pjm_app_push_manageSubscription', {
@@ -183,4 +184,22 @@ function push_sendSubscriptionToServer(subscription, action) {
     req.send(params);
 
     return true;
+}
+
+function getSubscriptionInfos(pushSubscription) {
+    endpoint = pushSubscription.endpoint;
+
+    // fix Chrome < 45
+    if (pushSubscription.subscriptionId &&
+        pushSubscription.endpoint.indexOf(pushSubscription.subscriptionId) === -1) {
+        endpoint = pushSubscription.endpoint + '/' + pushSubscription.subscriptionId;
+    }
+
+    var endpointSections = endpoint.split('/');
+    var subscriptionId = endpointSections[endpointSections.length - 1];
+
+    return {
+        subscriptionId: subscriptionId,
+        endpoint: endpoint
+    };
 }

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -24,7 +24,7 @@ framework:
             css:
                 version: v1r20150707
             sw:
-                version: v1r20150818
+                version: v1r20150828
     default_locale:  "%locale%"
     trusted_hosts:   ~
     trusted_proxies: ~

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "35c6f77dad7d7d35202a7c6876119496",
+    "hash": "5f58d370bd97c5997a2d8532df9b4e5b",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1875,7 +1875,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/froala/KMSFroalaEditorBundle/zipball/37cd29e200234e83de2467042c1e68e0b5e7f66e",
+                "url": "https://api.github.com/repos/froala/KMSFroalaEditorBundle/zipball/a3a73ce626724898cd3e393b93367329bb3beef8",
                 "reference": "63f4797e8d9593110c8a27b58c0693461b7478c9",
                 "shasum": ""
             },
@@ -2046,17 +2046,17 @@
         },
         {
             "name": "lexik/form-filter-bundle",
-            "version": "v3.0.7",
+            "version": "v3.0.8",
             "target-dir": "Lexik/Bundle/FormFilterBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lexik/LexikFormFilterBundle.git",
-                "reference": "dc3fd6b79bdeb855f96488c75c0bae97a67efc52"
+                "reference": "73eacc444e6f3314a5a5209cda52a58355388b66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lexik/LexikFormFilterBundle/zipball/dc3fd6b79bdeb855f96488c75c0bae97a67efc52",
-                "reference": "dc3fd6b79bdeb855f96488c75c0bae97a67efc52",
+                "url": "https://api.github.com/repos/lexik/LexikFormFilterBundle/zipball/73eacc444e6f3314a5a5209cda52a58355388b66",
+                "reference": "73eacc444e6f3314a5a5209cda52a58355388b66",
                 "shasum": ""
             },
             "require": {
@@ -2102,7 +2102,7 @@
                 "filter",
                 "form"
             ],
-            "time": "2015-05-29 12:20:25"
+            "time": "2015-06-12 15:46:04"
         },
         {
             "name": "liuggio/ExcelBundle",
@@ -2170,16 +2170,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.14.0",
+            "version": "1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "b287fbbe1ca27847064beff2bad7fb6920bf08cc"
+                "reference": "dc5150cc608f2334c72c3b6a553ec9668a4156b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b287fbbe1ca27847064beff2bad7fb6920bf08cc",
-                "reference": "b287fbbe1ca27847064beff2bad7fb6920bf08cc",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/dc5150cc608f2334c72c3b6a553ec9668a4156b0",
+                "reference": "dc5150cc608f2334c72c3b6a553ec9668a4156b0",
                 "shasum": ""
             },
             "require": {
@@ -2216,7 +2216,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.14.x-dev"
+                    "dev-master": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -2242,7 +2242,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2015-06-19 13:29:54"
+            "time": "2015-07-12 13:54:09"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -3066,16 +3066,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "932b6e7499c670f4db6d0b871477a4a3ca161e74"
+                "reference": "969d709ad428076bf1084e386dc26dd904d9fb84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/932b6e7499c670f4db6d0b871477a4a3ca161e74",
-                "reference": "932b6e7499c670f4db6d0b871477a4a3ca161e74",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/969d709ad428076bf1084e386dc26dd904d9fb84",
+                "reference": "969d709ad428076bf1084e386dc26dd904d9fb84",
                 "shasum": ""
             },
             "require": {
@@ -3184,7 +3184,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2015-06-11 21:15:28"
+            "time": "2015-07-13 19:27:49"
         },
         {
             "name": "twig/extensions",

--- a/src/PJM/AppBundle/Controller/PushController.php
+++ b/src/PJM/AppBundle/Controller/PushController.php
@@ -149,7 +149,7 @@ class PushController extends Controller
             'endpoint' => $request->request->get('endpoint'),
         );
 
-        if (empty($subscription['id']) && empty($subscription['id'])) {
+        if (empty($subscription['id']) && empty($subscription['endpoint'])) {
             $json = array(
                 'success' => false,
                 'done' => $action,

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -19,22 +19,25 @@ self.addEventListener('fetch', function (event) {
         return;
     }
 
-    // fix for unknown bug when redirecting after a form POST request
-    if (event.request.method === 'GET' && event.request.context === 'form') {
-        return;
-    }
-
     if (event.request.method === 'GET'
             && event.request.headers.get('accept').includes('text/html')) {
 
-        event.respondWith(
-            fetch(event.request).catch(function (e) {
-                // hors ligne
-                return caches.open(OFFLINE_CACHE).then(function (cache) {
-                    return cache.match(OFFLINE_URL);
-                });
-            })
-        );
+        // a request should not have any body (blob), but sometimes it does
+        event.request.blob().then(function(blob) {
+            if (blob.size == 0) {
+                event.respondWith(
+                    fetch(event.request).catch(function (e) {
+                        // hors ligne
+                        return caches.open(OFFLINE_CACHE).then(function (cache) {
+                            return cache.match(OFFLINE_URL);
+                        });
+                    })
+                );
+            } else {
+                console.warn("Bad GET request with body : " + event.request.url);
+                console.warn(blob);
+            }
+        });
     }
 });
 

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -25,7 +25,7 @@ self.addEventListener('fetch', function (event) {
     }
 
     if (event.request.method === 'GET'
-            && event.request.headers.get('accept').includes('text/html') !== -1) {
+            && event.request.headers.get('accept').includes('text/html')) {
 
         event.respondWith(
             fetch(event.request).catch(function (e) {


### PR DESCRIPTION
Retrocompatible with M44 and below. Updates push notifications and removal of Request.context.

Must obtain subscriptionId for RMSPushNotificationsBundle. In the future, maybe we should become independant of this bundle, yet we should wait for implementations of push notifications on other systems/browsers.