### PR TITLE
Custom URL for notifications

### DIFF
--- a/src/PJM/AppBundle/Controller/Consos/BragsAdminController.php
+++ b/src/PJM/AppBundle/Controller/Consos/BragsAdminController.php
@@ -85,7 +85,9 @@ class BragsAdminController extends Controller
                         $commande->valider();
 
                         $this->get('pjm.services.notification')->send('consos.commande.valider', array(
-                            'quantite' => $commande->showNombre()
+                            'quantite' => $commande->showNombre(),
+                            'item' => $commande->getItem()->getLibelle(),
+                            'path' => 'pjm_app_boquette_brags_index'
                         ), $commande->getUser(), false);
 
                         // on met à jour le prix de la commande car il pourrait avoir changé
@@ -93,7 +95,10 @@ class BragsAdminController extends Controller
 
                         $em->persist($commande);
                     } else {
-                        $this->get('pjm.services.notification')->send('consos.commande.resilier', array(), $commande->getUser(), false);
+                        $this->get('pjm.services.notification')->send('consos.commande.resilier', array(
+                            'item' => $commande->getItem()->getLibelle(),
+                            'path' => 'pjm_app_boquette_brags_index',
+                        ), $commande->getUser(), false);
 
                         // si c'est une demande de résiliation on supprime pour pas embrouiller l'historique
                         $em->remove($commande);
@@ -124,7 +129,10 @@ class BragsAdminController extends Controller
                     if ($commande->getValid() === true) {
                         $commande->resilier();
 
-                        $this->get('pjm.services.notification')->send('consos.commande.resilier', array(), $commande->getUser(), false);
+                        $this->get('pjm.services.notification')->send('consos.commande.resilier', array(
+                            'item' => $commande->getItem()->getLibelle(),
+                            'path' => 'pjm_app_boquette_brags_index',
+                        ), $commande->getUser(), false);
 
                         $em->persist($commande);
                     } elseif (null === $commande->getValid()) {

--- a/src/PJM/AppBundle/Controller/Consos/BragsAdminController.php
+++ b/src/PJM/AppBundle/Controller/Consos/BragsAdminController.php
@@ -87,7 +87,7 @@ class BragsAdminController extends Controller
                         $this->get('pjm.services.notification')->send('consos.commande.valider', array(
                             'quantite' => $commande->showNombre(),
                             'item' => $commande->getItem()->getLibelle(),
-                            'path' => 'pjm_app_boquette_brags_index'
+                            'path_params' => array('slug' => $this->slug),
                         ), $commande->getUser(), false);
 
                         // on met à jour le prix de la commande car il pourrait avoir changé
@@ -97,7 +97,7 @@ class BragsAdminController extends Controller
                     } else {
                         $this->get('pjm.services.notification')->send('consos.commande.resilier', array(
                             'item' => $commande->getItem()->getLibelle(),
-                            'path' => 'pjm_app_boquette_brags_index',
+                            'path_params' => array('slug' => $this->slug),
                         ), $commande->getUser(), false);
 
                         // si c'est une demande de résiliation on supprime pour pas embrouiller l'historique
@@ -131,7 +131,7 @@ class BragsAdminController extends Controller
 
                         $this->get('pjm.services.notification')->send('consos.commande.resilier', array(
                             'item' => $commande->getItem()->getLibelle(),
-                            'path' => 'pjm_app_boquette_brags_index',
+                            'path_params' => array('slug' => $this->slug),
                         ), $commande->getUser(), false);
 
                         $em->persist($commande);

--- a/src/PJM/AppBundle/DataFixtures/ORM/LoadNotificationsData.php
+++ b/src/PJM/AppBundle/DataFixtures/ORM/LoadNotificationsData.php
@@ -40,7 +40,7 @@ class LoadNotificationsData extends BaseFixture implements OrderedFixtureInterfa
             'consos' => array(
                 'quantite' => '1.5',
                 'item' => 'Baguette de pain',
-                'path' => 'pjm_app_boquette_brags_index',
+                'path_params' => array('slug' => 'brags'),
             ),
         );
 

--- a/src/PJM/AppBundle/DataFixtures/ORM/LoadNotificationsData.php
+++ b/src/PJM/AppBundle/DataFixtures/ORM/LoadNotificationsData.php
@@ -39,6 +39,8 @@ class LoadNotificationsData extends BaseFixture implements OrderedFixtureInterfa
             ),
             'consos' => array(
                 'quantite' => '1.5',
+                'item' => 'Baguette de pain',
+                'path' => 'pjm_app_boquette_brags_index',
             ),
         );
 

--- a/src/PJM/AppBundle/Entity/Notifications/Notification.php
+++ b/src/PJM/AppBundle/Entity/Notifications/Notification.php
@@ -70,7 +70,12 @@ class Notification
     /**
      * @var string
      */
-    private $path;
+    private $path = '';
+
+    /**
+     * @var array
+     */
+    private $pathParams = array();
 
     /**
      * @var bool
@@ -94,7 +99,6 @@ class Notification
         $this->date = new \DateTime();
         $this->received = false;
         $this->important = false;
-        $this->path = '';
         $this->type = '';
     }
 
@@ -322,5 +326,21 @@ class Notification
     public function setTitre($titre)
     {
         $this->titre = $titre;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPathParams()
+    {
+        return $this->pathParams;
+    }
+
+    /**
+     * @param array $pathParams
+     */
+    public function setPathParams($pathParams)
+    {
+        $this->pathParams = $pathParams;
     }
 }

--- a/src/PJM/AppBundle/Enum/Notifications/NotificationEnum.php
+++ b/src/PJM/AppBundle/Enum/Notifications/NotificationEnum.php
@@ -94,13 +94,13 @@ class NotificationEnum
         'consos.commande.valider' => array(
             'titre' => 'Commande validée',
             'type' => 'consos',
-            'path' => 'pjm_app_banque_index',
+            'path' => 'pjm_app_boquette_default',
             'infos' => array('quantite', 'item'),
         ),
         'consos.commande.resilier' => array(
             'titre' => 'Commande résiliée',
             'type' => 'consos',
-            'path' => 'pjm_app_banque_index',
+            'path' => 'pjm_app_boquette_default',
             'infos' => array('item'),
         ),
     );

--- a/src/PJM/AppBundle/Enum/Notifications/NotificationEnum.php
+++ b/src/PJM/AppBundle/Enum/Notifications/NotificationEnum.php
@@ -94,14 +94,14 @@ class NotificationEnum
         'consos.commande.valider' => array(
             'titre' => 'Commande validée',
             'type' => 'consos',
-            'path' => 'pjm_app_boquette_brags_index',
-            'infos' => array('quantite'),
+            'path' => 'pjm_app_banque_index',
+            'infos' => array('quantite', 'item'),
         ),
         'consos.commande.resilier' => array(
             'titre' => 'Commande résiliée',
             'type' => 'consos',
-            'path' => 'pjm_app_boquette_brags_index',
-            'infos' => array(),
+            'path' => 'pjm_app_banque_index',
+            'infos' => array('item'),
         ),
     );
 

--- a/src/PJM/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/PJM/AppBundle/Resources/translations/messages.fr.yml
@@ -23,5 +23,5 @@ notifications:
       nouvelle: <span class="info">%auteur%</span> a publié un nouvel article intitulé <span class="info">%titre%</span>.
     consos:
       commande:
-        valider: Ta commande de Brag's a été validée. Tu recevras désormais <span class="info">%quantite%</span> baguette(s) par jour.
-        resilier: Ta commande de Brag's a été résiliée.
+        valider: Ta commande de <span class="info">%item%</span> a été validée. Tu en recevras désormais <span class="info">%quantite%</span> par jour.
+        resilier: Ta commande de <span class="info">%item%</span> a été résiliée.

--- a/src/PJM/AppBundle/Resources/views/Notifications/notification.html.twig
+++ b/src/PJM/AppBundle/Resources/views/Notifications/notification.html.twig
@@ -5,7 +5,7 @@
     </div>
     <div class="message">
         {{ ("notifications.content." ~ notification.key)|trans(notification.variables)|purify }}
-        {% if notification.path != "" %}<a href="{{ path(notification.path) }}" title="Plus d'infos"><span class="glyphicon glyphicon-link"></span></a>{% endif %}
+        {% if notification.path != "" %}<a href="{{ path(notification.path, notification.pathParams) }}" title="Plus d'infos"><span class="glyphicon glyphicon-link"></span></a>{% endif %}
     </div>
     <div class="date">{{ notification.date|localizeddate('full', 'none') }} <span class="heure">{{ notification.date|localizeddate('none', 'short') }}</span></div>
 </div>

--- a/src/PJM/AppBundle/Services/Event/InvitationManager.php
+++ b/src/PJM/AppBundle/Services/Event/InvitationManager.php
@@ -109,6 +109,7 @@ class InvitationManager
         $this->notification->send('event.invitation', array(
             'event' => $event->getNom(),
             'date' => $event->getDateDebut()->format('d/m/Y à H:i'),
+            'path_params' => array('slug' => $event->getSlug()),
         ), $notifUsers);
 
         $this->notification->sendFlash(

--- a/src/PJM/AppBundle/Services/NotificationManager.php
+++ b/src/PJM/AppBundle/Services/NotificationManager.php
@@ -50,9 +50,9 @@ class NotificationManager
         }
 
         // on vérifie qu'il y a les bonnes infos pour remplir le message
-        // attention là il faut mettre les clés dans le bon ordre aussi...
-        if ($notificationType['infos'] != array_keys($infos)) {
-            return false;
+        foreach (array_keys($notificationType['infos']) as $key) {
+            if (!array_key_exists($key, $infos))
+                return false;
         }
 
         if ($users instanceof User) {
@@ -171,6 +171,11 @@ class NotificationManager
 
                 // on vérifie que l'utilisateur est abonné ou non au type de notification, et si oui on indique "important"
                 $notification->setImportant($settings->has($notificationType['type']));
+            }
+
+            if (array_key_exists('path', $infos)) {
+                // si la notification a un custom path
+                $notification->setPath($infos['path']);
             }
 
             return $notification;


### PR DESCRIPTION
By default, uses `path` defined in NotificationEnum. You can override `path` by adding a `path` to `$infos` during `send`.

You can specify path parameters by adding `path_params` to `$infos` during `send`.

See changed files for example (InvitationManager).

